### PR TITLE
Link with correct libraries

### DIFF
--- a/install/cx/build/cxComponents.py
+++ b/install/cx/build/cxComponents.py
@@ -509,7 +509,7 @@ class OpenCLUtilityLibrary(CppComponent):
         return 'git@github.com:smistad/OpenCLUtilityLibrary'
     def update(self):
         self._getBuilder().gitSetRemoteURL(self.repository())
-        self._getBuilder().gitCheckout('43614718f7667dd5013af9300fcc63ae30bf244c')
+        self._getBuilder().gitCheckout('7a4258fab2ce30ca0c9fac347efd903124f39d09')
     def configure(self):
         builder = self._getBuilder()
         builder.configureCMake()
@@ -531,7 +531,7 @@ class FAST(CppComponent):
 		return 'git@github.com:smistad/FAST'
     def update(self):
         self._getBuilder().gitSetRemoteURL(self.repository())
-        self._getBuilder().gitCheckout('ab6386042cd3d2417a8e0ce5d3871242ab4913ab')
+        self._getBuilder().gitCheckout('f81836597db0529f2b8e23d5ee9236cef7377b48')
 #        branch = 'set_kernel_root_dir'
 #        self._getBuilder()._changeDirToSource()
 #        runShell('git checkout %s' % branch, ignoreFailure=False)

--- a/source/plugins/org.custusx.filter.airways/CMakeLists.txt
+++ b/source/plugins/org.custusx.filter.airways/CMakeLists.txt
@@ -5,6 +5,7 @@ include(cxInstallUtilities)
 macro(cx_initialize_FAST)
     find_package(FAST REQUIRED)
     include_directories("${FAST_DIR}/../FAST/source/")
+    include_directories("${FAST_DIR}/")
     link_directories("${FAST_DIR}/lib/")
     set(FAST_SOURCE_DIR ${FAST_DIR}/../FAST/source/FAST/)
     add_definitions("-DFAST_SOURCE_DIR=\"${FAST_SOURCE_DIR}/\"")
@@ -64,12 +65,22 @@ install(DIRECTORY ${FAST_SOURCE_DIR}
 
 #Compute the plugin dependencies
 ctkFunctionGetTargetLibraries(PLUGIN_target_libraries)
+# Z lib comes with many names, needed for FAST atm
+if(WIN32)
+    set(ZLIB zlib.lib)
+elseif(APPLE)
+    set(ZLIB libz.dylib)
+else()
+    set(ZLIB libz.so)
+endif()
 set(PLUGIN_target_libraries
     PUBLIC
     ${PLUGIN_target_libraries}
+    FAST
 
     PRIVATE
-    ${FAST_LIBRARIES}
+    ${OPENCL_LIBRARIES}
+    ${ZLIB}
     cxResource
     cxResourceFilter
     cxResourceVisualization

--- a/source/plugins/org.custusx.filter.airways/CMakeLists.txt
+++ b/source/plugins/org.custusx.filter.airways/CMakeLists.txt
@@ -69,9 +69,7 @@ set(PLUGIN_target_libraries
     ${PLUGIN_target_libraries}
 
     PRIVATE
-    FAST
-    Qt5::OpenGL
-    ${OPENCL_LIBRARIES}
+    ${FAST_LIBRARIES}
     cxResource
     cxResourceFilter
     cxResourceVisualization


### PR DESCRIPTION
This will hopefully link the plugin with the external libraries on windows. FAST_LIBRARIES comes from FASTConfig.cmake and should contain FAST, zlib, OpenCL, ++